### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,15 @@
     ],
     "require": {
         "php": ">=8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "alexcrawford/lexorank-php": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^11.0",
-        "orchestra/testbench": "^8.0|^9.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "laravel/pint": "^1.25",
         "phpstan/phpstan": "^2.1",
-        "phpunit/php-code-coverage": "^11.0"
+        "phpunit/php-code-coverage": "^11.0|^12.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Widen `illuminate/support` to include `^13.0` and bump dev deps (phpunit `^12`, orchestra/testbench `^11`, php-code-coverage `^12`) for Laravel 13 testing.

Full suite passes on **Laravel 13.18.0: 419 tests, 8538 assertions**. Backward compatible with Laravel 10–12.

Needed for the EventWorks Laravel 12 → 13 upgrade (lexorank-sortable's `illuminate/support ^12` cap blocks framework 13).